### PR TITLE
Property API - fixed json example (invalid tz)

### DIFF
--- a/apis/02-Product Management/03-Property-API/01-api-definition.md
+++ b/apis/02-Product Management/03-Property-API/01-api-definition.md
@@ -53,7 +53,7 @@ The below example is a request to onboard a new property using SetPropertyDetail
     "structureType": "Hotel",
     "currencyCode": "USD",
     "billingCurrencyCode": "USD",
-    "timeZone": "USA/Pacific",
+    "timeZone": "America/Los_Angeles",
     "addresses": [
         {
             "line1": "123 Main St.",
@@ -200,7 +200,7 @@ The below example is a request to onboard a new property using SetPropertyDetail
 | structureType | String | No | Yes | Must use pre-defined structureType code.  See [code list](./Code-list.html#StructureType "Structure type codes") |
 | currencyCode | String | Yes | No | Currency code to be used for property's pricing. Cannot be updated after initial onboarding. Use ISO4217 |
 | billingCurrencyCode | String | Yes | No | Currency code to be used for billing. Use ISO4217. |
-| timeZone | String | Yes | Yes | TimeZone for the property, used to determine cancel policies. Use the IANA timezone database codes. |
+| timeZone | String | Yes | Yes | TimeZone for the property, used to determine cancel policies. Use the [tz database](./https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) |
 | addresses | Array of Address objects | Yes | No | See Address below. |
 | ratings | Array of Rating objects | No | No | See Rating below. |
 | contacts | Dictionary of Contact objects | Yes | Yes | See Contact below. |

--- a/apis/02-Product Management/03-Property-API/02-supported-features.md
+++ b/apis/02-Product Management/03-Property-API/02-supported-features.md
@@ -16,7 +16,7 @@ The following sections indicate specific use cases that are supported or not sup
 | Supported | Not Supported |
 | --------- | ------------- |
 | Expedia Collect-only Properties | Hotel Collect-only Properties |
-| Flex Properties (offering both Expedia Collect and Hotel Collect products) | *Changing a property's business model via API |
+| ETP Properties (offering both Expedia Collect and Hotel Collect products) | *Changing a property's business model via API |
 
 Property API supports the onboarding of new properties that offer either Expedia Collect products only OR offers both Expedia Collect and Hotel Collect products.  *Contact your account manager if you wish to support changing a property's business model via the API.   
 


### PR DESCRIPTION
Minor but important content tweak - had an invalid timezone in the json request example that was confusing partners.  Also replaced "flex" with "ETP" to be consistent with Product API docs.