### PR TITLE
Update BookingRetrievalRS.xsd

### DIFF
--- a/apis/01-Availability, Rates, Restrictions, Booking Notification, Retrieval and Confirmation/03-Expedia-QuickConnect-Booking-Retrieval-&-Confirmation-API/02-reference-br.md
+++ b/apis/01-Availability, Rates, Restrictions, Booking Notification, Retrieval and Confirmation/03-Expedia-QuickConnect-Booking-Retrieval-&-Confirmation-API/02-reference-br.md
@@ -143,7 +143,7 @@ OR
 3|@code|Enum||Reward program code, as defined by Expedia.
 3|@number|String||Customer's account no - unique ID from reward program card number <p>String length does not exceed 32 characters</p>
 3|SpecialRequest|String|*|Special Request made by the customer. Can have up to 6 different special requests, and each one can be one of 6 types:<ul><li>Bedding type</li><li>Smoking/Non-smoking</li><li>Multi-room booking</li><li>Free text (guest comments entered at booking on Expedia)</li><li>Payment instructions</li><li>Value Add Promotions</li></ul><p>Types are identified by code attribute on this element.</p><p>String length does not exceed 256 characters.</p>
-3|@code|Enum||Expedia-defined code associated to special request: <ul><li>(1.x) bedding preferences w/ different codes for beddings</li><li>(2) smoking/no smoking </li><li>(3) indication of multi room bookings</li><li>(4) free text</li><li>(5) payment instructions</li><li>(6) Value Add Promotions</li></ul><p>Please visit the [Special Request Codes](#/SpecialRequestCodes) section for an exhaustive list of possible code. .</p>
+3|@code|Enum||Expedia-defined code associated to special request: <ul><li>(1.x) bedding preferences w/ different codes for beddings</li><li>(2) smoking/no smoking </li><li>(3) indication of multi room bookings</li><li>(4) free text</li><li>(5) payment instructions</li><li>(6) Value Add Promotions</li></ul><p>Please visit the [Special Request Codes](#SpecialRequestCodes) section for an exhaustive list of possible code. .</p>
 
 ### Booking Retrieval Response Types
 

--- a/files/BookingRetrievalRS.xsd
+++ b/files/BookingRetrievalRS.xsd
@@ -406,7 +406,7 @@ Promotions may also be referred to as DRRs, or Dynamic Rate Rules.</xs:documenta
                                                 </xs:attribute>
                                             </xs:complexType>
                                         </xs:element>
-                                        <xs:element name="SpecialRequest" minOccurs="0" maxOccurs="5">
+                                        <xs:element name="SpecialRequest" minOccurs="0" maxOccurs="99">
                                             <xs:annotation>
                                                 <xs:documentation>Special Request made by the customer. Can have up to 5 different special requests, and each one can be one out of 5 types:
 •Bedding Type

--- a/files/OTA_HotelResModifyNotifRQ.xsd
+++ b/files/OTA_HotelResModifyNotifRQ.xsd
@@ -1212,7 +1212,7 @@ to be added to the OTA specification per trading partner agreement.</xs:document
 A collection of SpecialRequest objects. The collection of all special requests associated with any part of the reservation (the reservation in its entirety, one or more guests, or one or more room stays).  Which special requests belong to which part is determined by each object's SpecialRequestRPHs collection.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="SpecialRequest" maxOccurs="5">
+      <xs:element name="SpecialRequest" maxOccurs="99">
         <xs:annotation>
           <xs:documentation xml:lang="en">The SpecialRequest object indicates special requests for a particular guest, service or reservation.  Each of these may be independent of any that are tied to the profile (see Profile Synchronization standard).</xs:documentation>
         </xs:annotation>

--- a/files/OTA_HotelResNotifRQ.xsd
+++ b/files/OTA_HotelResNotifRQ.xsd
@@ -1198,7 +1198,7 @@ to be added to the OTA specification per trading partner agreement.</xs:document
 A collection of SpecialRequest objects. The collection of all special requests associated with any part of the reservation (the reservation in its entirety, one or more guests, or one or more room stays).  Which special requests belong to which part is determined by each object's SpecialRequestRPHs collection.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="SpecialRequest" maxOccurs="5">
+      <xs:element name="SpecialRequest" maxOccurs="99">
         <xs:annotation>
           <xs:documentation xml:lang="en">The SpecialRequest object indicates special requests for a particular guest, service or reservation.  Each of these may be independent of any that are tied to the profile (see Profile Synchronization standard).</xs:documentation>
         </xs:annotation>


### PR DESCRIPTION
PR to fix BN and BR schemas to change number of allowed special requests from 5 to 99 (fix related to value add promos problem with some partners where it causes number of special requests to go to 6).