### PR TITLE
Rename media guid to resource id for eps image service

### DIFF
--- a/apis/02-Product Management/05-Image-API-(Experimental)/02-reference.md
+++ b/apis/02-Product Management/05-Image-API-(Experimental)/02-reference.md
@@ -243,7 +243,7 @@ Status Code | Description | Response Model
 It is important for partners to know images can only be deleted before they reach the Published state.
 
 - Method: `DELETE`
-- Url: https://services.expediapartnercentral.com/properties/{propertyId}/images/{guid}
+- Url: https://services.expediapartnercentral.com/properties/{propertyId}/images/{resourceId}
 - Consumes: `application/json`
 - Produces: `*/*`
 
@@ -251,11 +251,11 @@ It is important for partners to know images can only be deleted before they reac
 Parameter | Parameter Type | Description | Required | Data Type | Default Value
 --------- | -------------- | ----------- | -------- | --------- | -------------
 propertyId | path | Expedia Property ID | true | string | 
-guid | path | Image ResourceId. The DELETE only works on images that haven't reached the "Published" state. Once it reached "Published", it can't be deleted anymore, only inactivated. | true | string | 
+resourceId | path | Image Resource ID. The DELETE only works on images that haven't reached the "Published" state. Once it reached "Published", it can't be deleted anymore, only inactivated. | true | string | 
 
 ### Read a single image
 - Method: `GET`
-- Url: https://services.expediapartnercentral.com/properties/{propertyId}/images/{guid}
+- Url: https://services.expediapartnercentral.com/properties/{propertyId}/images/{resourceId}
 - Consumes: `application/json`
 - Produces: `application/json`
 
@@ -279,7 +279,7 @@ guid | path | Image ResourceId. The DELETE only works on images that haven't rea
 Parameter | Parameter Type | Description | Required | Data Type | Default Value
 --------- | -------------- | ----------- | -------- | --------- | -------------
 propertyId | path | Expedia Property ID | true | string | 
-guid | path | Image GUID | true | string | 
+resourceId | path | Image Resource ID | true | string | 
 
 #### Success Responses
 Status Code | Description | Response Model

--- a/apis/02-Product Management/05-Image-API-(Experimental)/06-revision-history.md
+++ b/apis/02-Product Management/05-Image-API-(Experimental)/06-revision-history.md
@@ -2,6 +2,7 @@
 
 | Date | Changes |
 | ---- | ---------------- |
+| 2016-09-10 | Rename guid by resourceId |
 | 2016-08-24 | Clarified categories and added examples |
 | 2016-08-19 | Image API v1 officially live |
 

--- a/files/image_swagger.json
+++ b/files/image_swagger.json
@@ -113,7 +113,7 @@
 					"Image"
 				],
 				"summary": "Read a single image",
-				"operationId": "getImageByGuid",
+				"operationId": "getImageByResourceId",
 				"consumes": [
 					"application/json"
 				],
@@ -152,7 +152,7 @@
 					"Image"
 				],
 				"summary": "Delete an existing image",
-				"operationId": "deleteImageByGuid",
+				"operationId": "deleteImageByResourceId",
 				"consumes": [
 					"application/json"
 				],

--- a/files/image_swagger.json
+++ b/files/image_swagger.json
@@ -107,7 +107,7 @@
 				]
 			}
 		},
-		"/properties/{propertyId}/images/{guid}": {
+		"/properties/{propertyId}/images/{resourceId}": {
 			"get": {
 				"tags": [
 					"Image"
@@ -128,9 +128,9 @@
 						"required": true,
 						"type": "string"
 					}, {
-						"name": "guid",
+						"name": "resourceId",
 						"in": "path",
-						"description": "Image GUID",
+						"description": "Image Resource ID",
 						"required": true,
 						"type": "string"
 					}
@@ -167,9 +167,9 @@
 						"required": true,
 						"type": "string"
 					}, {
-						"name": "guid",
+						"name": "resourceId",
 						"in": "path",
-						"description": "Image GUID",
+						"description": "Image Resource ID",
 						"required": true,
 						"type": "string"
 					}


### PR DESCRIPTION
Parameter in URL and operationId that contained "GUID" have been updated to replace "GUID" by "ResourceID"