### PR TITLE
Removing Distribution Models from sample messages

### DIFF
--- a/apis/02-Product Management/03-Property-API-(Contact Expedia Group Before Adopting)/01-api-definition.md
+++ b/apis/02-Product Management/03-Property-API-(Contact Expedia Group Before Adopting)/01-api-definition.md
@@ -180,10 +180,6 @@ The below example is a request to onboard a new property using SetPropertyDetail
     ],
     "inventorySettings": {
         "rateAcquisitionType": "NET_RATE",
-        "distributionModels": [
-            "EXPEDIA_COLLECT",
-            "HOTEL_COLLECT"
-        ],
         "pricingModel": "PER_DAY"
     },
     "attributes": [
@@ -342,7 +338,6 @@ While a property needs at least 1 image to complete onboarding, we recommend all
 | Attribute | Type | Required | Notes |
 | --------- | ---- | -------- | ----- |
 | rateAcquisitionType | String | No | See [code list](./code-list.html#property-inventorysetting-rateacquisitiontype)|
-| distributionModels | String | No | See [code list](./code-list.html#property-inventorysetting-distributionmodels)|
 | pricingModel | String | No | See [code list](./code-list.html#property-inventorysetting-pricingmodel)|
 
 **tax**
@@ -541,10 +536,6 @@ The response body will echo back the values of *the request received* and will i
             ],
             "inventorySettings": {
                 "rateAcquisitionType": "NET_RATE",
-                "distributionModels": [
-                    "EXPEDIA_COLLECT",
-                    "HOTEL_COLLECT"
-                ],
                 "pricingModel": "PER_DAY"
             },
             "attributes": [
@@ -815,10 +806,6 @@ GET /properties/v1/mycompany/1234
     ],
       "inventorySettings": {
             "rateAcquisitionType": "SELL_LAR",
-            "distributionModels": [
-                "HOTEL_COLLECT",
-                "EXPEDIA_COLLECT"
-            ],
             "pricingModel": "PER_DAY",
             "onStopSell": true
         },


### PR DESCRIPTION
Business has provided feedback that in most cases, we dont want partners to specify this in onboarding Request, rather default it to what we have. There will be some partners (very rare) who support more than one model and in those cases, we will provide them the details offline.